### PR TITLE
Add built commonjs module definition to packed module.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "the-orange-alliance-api",
+  "name": "@the-orange-alliance/api",
   "version": "0.0.1",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -5,13 +5,17 @@
   "author": "The Orange Alliance, Josh Bacon",
   "license": "MIT",
   "keywords": [],
-  "main": "./lib/index.js",
-  "types": "./lib/index.d.ts",
+  "main": "lib",
+  "types": "lib",
+  "module": "src",
   "scripts": {
     "build": "tsc",
     "prepare": "npm run build",
     "test": "jest"
   },
+  "files": [
+    "lib"
+  ],
   "directories": {
     "lib": "lib",
     "test": "tests"


### PR DESCRIPTION
Allow nodejs usage of the project by including the lib folder with the package.