### PR TITLE
Fixed an obscure bug with skystone events

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -136,7 +136,9 @@ export class API {
         responseData: string
     ): T[] {
         let res: [any] = JSON.parse(responseData);
-        let x = res.map((value) => new c().fromJSON(value) as T);
+        let x = res
+            .filter((v) => v !== null)
+            .map((value) => new c().fromJSON(value) as T);
         return x;
     }
 


### PR DESCRIPTION
Fixes [the-orange-alliance/the-orange-alliance#91](https://github.com/the-orange-alliance/the-orange-alliance/issues/91) by running a check for null values before serialization.

This seems to be caused by some bug further up the chain that makes the first element in `getTeamRankings()` (`/api/team/${teamKey}/results/${seasonKey}`) be a null value when the `seasonKey` is '1920'